### PR TITLE
Totem Bar fix

### DIFF
--- a/Bartender4/MultiCastBar.lua
+++ b/Bartender4/MultiCastBar.lua
@@ -3,7 +3,7 @@
 	All rights reserved.
 ]]
 
-if not HasMultiCastActionBar or select(2, UnitClass("player")) ~= "DRUID" then return end
+if not HasMultiCastActionBar then return end
 
 -- fetch upvalues
 local L = LibStub("AceLocale-3.0"):GetLocale("Bartender4")

--- a/Bartender4/Options/MultiCastBar.lua
+++ b/Bartender4/Options/MultiCastBar.lua
@@ -3,7 +3,7 @@
 	All rights reserved.
 ]]
 
-if not HasMultiCastActionBar or select(2, UnitClass("player")) ~= "DRUID" then return end
+if not HasMultiCastActionBar then return end
 
 -- fetch upvalues
 local L = LibStub("AceLocale-3.0"):GetLocale("Bartender4")


### PR DESCRIPTION
Shows Totem bar & Enable it in config, if player `HasMultiCastActionBar()`;
`HasMultiCastActionBar()` returns `true` if player knows any totem, thus there's no need to check for player's class.